### PR TITLE
Record flight replay to share

### DIFF
--- a/src/flight_analysis/maps/renderer.ts
+++ b/src/flight_analysis/maps/renderer.ts
@@ -317,6 +317,11 @@ export default class Renderer {
     console.log(`Flight removed id=${flightDatum.id}`);
   }
 
+  getCanvas(): HTMLCanvasElement | null {
+    if (!this.map) return null;
+    return this.map.getCanvas() as HTMLCanvasElement;
+  }
+
   setTime(timestamp: Date) {
     if (!this.map) return;
 


### PR DESCRIPTION
A simple prototype that records the flight animation.

- It records the results of the canvas into an MP4 video.
  - Works on safari
  - Does not record any of the HTML elements, so for instance the glider icons
      do not show up as mapbox renders these as HTML absolutely positioned over
      the canvas.

Alternate approaches:

- Move the recording to the backend, use something like Puppetter to drive the
    browser and record the video.
  - This looks like it packages a bunch of the boilerplate: https://github.com/tungs/timecut

https://user-images.githubusercontent.com/2349448/210968082-2e5fec9b-2355-4c97-b59e-d7b9d26cf0cc.mp4

