### PR TITLE
Spike driving markers w/ symbol layers

### DIFF
--- a/src/flight_analysis/store/models/flight_datum.ts
+++ b/src/flight_analysis/store/models/flight_datum.ts
@@ -24,6 +24,14 @@ export class FlightDatum {
     this.pictures = extra.pictures || [];
   }
 
+  get label(): string {
+    return (
+      this.flight.metadata.callsign ||
+      this.flight.metadata.registration ||
+      "G-DOE"
+    );
+  }
+
   get task(): Task | null {
     return this.flight.task;
   }

--- a/src/ui/components/flight_label.tsx
+++ b/src/ui/components/flight_label.tsx
@@ -1,14 +1,9 @@
-import SavedFlight from "glana/src/saved_flight";
 import { FlightDatum } from "../../flight_analysis/store/models/flight_datum";
 
 interface Props {
   flightDatum: FlightDatum;
   isActive: boolean;
 }
-
-const labelText = (flight: SavedFlight) => {
-  return flight.metadata.callsign || flight.metadata.registration || "G-DOE";
-};
 
 const containerClasses = () => {
   const textSize = "text-base";
@@ -28,7 +23,7 @@ export default function FlightLabel(props: Props) {
           borderColor: color,
         }}
       ></div>
-      <div className="overflow-hidden">{labelText(flightDatum.flight)}</div>
+      <div className="overflow-hidden">{flightDatum.label}</div>
     </div>
   );
 }


### PR DESCRIPTION
Using symbol layers instead of markers will render the icon into the canvas.
Doing so, will allow us to record the canvas animation including the glider
markers.
